### PR TITLE
Fix setting the timezone

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -1716,9 +1716,9 @@ configure_system() {
 		fi
 	fi
 
-	(arch-chroot "$ARCH" ln -s /usr/share/zoneinfo/"$ZONE" /etc/localtime
+	(arch-chroot "$ARCH" ln -sf /usr/share/zoneinfo/"$ZONE" /etc/localtime
 	sleep 0.5) &
-	pid=$! pri=0.1 msg="\n$zone_load_var \n\n \Z1> \Z2ln -s $ZONE /etc/localtime\Zn" load
+	pid=$! pri=0.1 msg="\n$zone_load_var \n\n \Z1> \Z2ln -sf $ZONE /etc/localtime\Zn" load
 
 	case "$net_util" in
 		networkmanager)	arch-chroot "$ARCH" systemctl enable NetworkManager.service &>/dev/null


### PR DESCRIPTION
Creating the symlink fails since /etc/localtime already exists. The problem is fixed by adding -f to the ln command.