### PR TITLE
Install bash-comlpetion if bash shell is chosen

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -1070,6 +1070,8 @@ prepare_base() {
 				fi
 			else
 				case "$shell" in
+                                        bash) sh="/bin/bash" shell="bash-completion"
+                                        ;;
 					fish) 	sh="/bin/bash"
 					;;
 					zsh) sh="/usr/bin/$shell" shell="zsh zsh-syntax-highlighting"


### PR DESCRIPTION
Having bash-completion installed when "bash" is selected is a no brainier for me. It is a must have tool and I think we should have it right out of the box.