### PR TITLE
Properly set localelist variable so that the dialog shows up

### DIFF
--- a/etc/arch-anywhere.conf
+++ b/etc/arch-anywhere.conf
@@ -281,7 +281,7 @@ if (lscpu | grep "Intel" &> /dev/null); then intel=true ; fi
 zonelist=$(find /usr/share/zoneinfo -maxdepth 1 | sed -n -e 's!^.*/!!p' | grep -v "posix\|right\|zoneinfo\|zone.tab\|zone1970.tab\|W-SU\|WET\|posixrules\|MST7MDT\|iso3166.tab\|CST6CDT" | sort | sed 's/$/ -/g')
 
 ### Full list of locales
-localelist=$(</etc/locale.gen  grep -F ".UTF-8" | awk '{print $1" ""-"}' | sed 's/#//')
+localelist=$(grep -E "^#?[a-z].*UTF-8" /etc/locale.gen | sed 's/#//' | awk '{print $1" -"}')
 
 ### List of countries for mirrorlist update
 countries=$(echo -e "AL All\n AS All-Https\n AT Austria\n AU  Australia\n BE Belgium\n BG Bulgaria\n BR Brazil\n BY Belarus\n CA Canada\n CL Chile \n CN China\n CO Columbia\n CZ Czech-Republic\n DE Germany\n DK Denmark\n EE Estonia\n ES Spain\n FI Finland\n FR France\n GB United-Kingdom\n HU Hungary\n IE Ireland\n IL Isreal\n IN India\n IT Italy\n JP Japan\n KR Korea\n KZ Kazakhstan\n LK Sri-Lanka\n LU Luxembourg\n LV Latvia\n MK Macedonia\n NC New-Caledonia\n NL Netherlands\n NO Norway\n NZ New-Zealand\n PL Poland\n PT Portugal\n RO Romania\n RS Serbia\n RU Russia\n SE Sweden\n SG Singapore\n SK Slovakia\n TR Turkey\n TW Taiwan\n UA Ukraine\n US United-States\n UZ Uzbekistan\n VN Viet-Nam\n ZA South-Africa")


### PR DESCRIPTION
The "localelist" variable was not set correctly which causes the dialog to throw an error and the menu to never show up. This is fixed with the new regular expression.