### PR TITLE
Add support for auto partitioning software RAID

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -291,7 +291,7 @@ prepare_drives() {
 			prepare_drives
 		fi
 
-		if [[ "$DRIVE" == nvme* ]] || [[ "$DRIVE" == mmc* ]]; then
+		if (<<<"$DRIVE" egrep "nvme.*|mmc.*|md.*" &> /dev/null) then
 			PART_PREFIX="p"
 		fi
 


### PR DESCRIPTION
As of now formatting and installing on RAID devices with no partitions is not supported.
The software RAID device must be created and configured in advance outside the installer.