### PR TITLE
Rewritten part_menu function

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -850,7 +850,7 @@ part_class() {
 								mkfs."$FS" /dev/"$part" &> /dev/null &
 							;;
 						esac
-						pid=$! pri=1 msg="\n$load_var1 \n\n \Z1> \Z2mkfs.FS /dev/$part\Zn" load
+						pid=$! pri=1 msg="\n$load_var1 \n\n \Z1> \Z2mkfs.$FS /dev/$part\Zn" load
 					else
 						part_menu
 					fi

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -605,7 +605,7 @@ part_menu() {
 		if (<<<"$dev_type" egrep "disk|raid[0-9]+" &> /dev/null) then
 			echo "\"$device\" \"$dev_size ---- ---- ---- $dev_type\" \\" >> $tmp_list
 		else
-				mnt_point=$(df | grep -w "$device" | awk '{print $6}')
+				mnt_point=$(df | grep -w "$device" | awk '{print $6}' | sed 's/mnt\/\?//')
 				if (<<<"$mnt_point" grep "/" &> /dev/null) then
 					fs_type="$(df -T | grep -w "$device" | awk '{print $2}')"
 					part_used=$(df -T | grep -w "$device" | awk '{print $6}')

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -644,17 +644,9 @@ part_menu() {
 					fi
 				fi
 
-				if [ -z $part_used ]; then
-					part_used="----"
-				fi
-
-				if [ -z $fs_type ]; then
-					fs_type="----"
-				fi
-
-				if [ -z $mnt_point ]; then
-					mnt_point="----"
-				fi
+				test -z "$part_used" && part_used="----"
+				test -z "$fs_type" && fs_type="----"
+				test -z "$mnt_point" && mnt_point="----"
 
 				echo "\"$device\" \"$dev_size $part_used $fs_type $mnt_point $part_type\" \\" >> "$tmp_list"
 				unset part_type

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -666,6 +666,7 @@ part_class() {
 
 	op_title="$edit_op_msg"
 	if [ -z "$part" ]; then
+		unset DRIVE ROOT
 		prepare_drives
 	elif (<<<$part grep -E "sd[a-z]+[0-9]+|[a-z]+[[:alnum:]]+p[0-9]+" &> /dev/null); then
 		part_size=$(fdisk -l | grep -w "$part" | sed 's/\*//' | awk '{print $5}')

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,7 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_list=$(lsblk | egrep -v "NAME|loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq)
+	device_list=$(lsblk -n | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq)
 	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,7 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_list=$(lsblk -n | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq)
+	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:] ]//g' | column -t | sort | uniq)
 	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then
@@ -600,7 +600,7 @@ part_menu() {
 	empty_value="----"
 	until [ "$int" -gt "$device_count" ]
 	do
-		device=$(<<<"$device_list" awk '{print $1}' | sed 's/[^[:alnum:]]//g' | awk "NR==$int")
+		device=$(<<<"$device_list" awk '{print $1}' | awk "NR==$int")
 		dev_type=$(<<<"$device_list" grep -w "$device" | awk '{print $6}')
 		dev_size=$(<<<"$device_list" grep -w "$device" | awk '{print $4}')
 		dev_fs=$(lsblk -no FSTYPE "$device" | head -1)

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,8 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_count=$(lsblk | egrep -v "NAME|loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq | wc -l)
+	device_list=$(lsblk | egrep -v "NAME|loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq)
+	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then
 		echo "dialog --extra-button --extra-label \"$write\" --colors --backtitle \"$backtitle\" --title \"$op_title\" --ok-button \"$edit\" --cancel-button \"$cancel\" --menu \"$manual_part_msg \n\n $dev_menu\" 21 68 9 \\" > "$tmp_menu"
@@ -598,9 +599,9 @@ part_menu() {
 	int=1
 	until [ "$int" -gt "$device_count" ]
 	do
-		device=$(lsblk | egrep -v "NAME|loop[0-9]+|sr[0-9]+|fd[0-9]+" | sort | uniq | awk '{print $1}' | sed 's/[^[:alnum:]]//g' | awk "NR==$int")
-		dev_type=$(lsblk | grep -m 1 -w "$device" | awk '{print $6}')
-		dev_size=$(lsblk | grep -m 1 -w "$device" | awk '{print $4}')
+		device=$(<<<"$device_list" awk '{print $1}' | sed 's/[^[:alnum:]]//g' | awk "NR==$int")
+		dev_type=$(<<<"$device_list" grep -w "$device" | awk '{print $6}')
+		dev_size=$(<<<"$device_list" grep -w "$device" | awk '{print $4}')
 
 		if (<<<"$dev_type" egrep "disk|raid[0-9]+" &> /dev/null) then
 			echo "\"$device\" \"$dev_size ---- ---- ---- $dev_type\" \\" >> $tmp_list

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -603,7 +603,7 @@ part_menu() {
 		device=$(<<<"$device_list" awk '{print $1}' | awk "NR==$int")
 		dev_type=$(<<<"$device_list" grep -w "$device" | awk '{print $6}')
 		dev_size=$(<<<"$device_list" grep -w "$device" | awk '{print $4}')
-		dev_fs=$(lsblk -no FSTYPE "$device" | head -1)
+		dev_fs=$(lsblk -no FSTYPE "/dev/$device" | head -1)
 		test -z "$dev_fs" && dev_fs=$empty_value
 
 		if (<<<"$dev_type" egrep "disk|raid[0-9]+" &> /dev/null) then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -620,31 +620,31 @@ part_menu() {
 		test -z "$dev_mnt" && dev_mnt=$empty_value
 
 		if (<<<"$dev_type" egrep -v "disk|raid[0-9]+" &> /dev/null) then
-				if (fdisk -l | grep "gpt" &>/dev/null) then
-					part_type_uuid=$(fdisk -l -o Device,Size,Type-UUID | grep -w "$device" | awk '{print $3}')
+			if (fdisk -l | grep "gpt" &>/dev/null) then
+				part_type_uuid=$(fdisk -l -o Device,Size,Type-UUID | grep -w "$device" | awk '{print $3}')
 
-					if [ $part_type_uuid == "0FC63DAF-8483-4772-8E79-3D69D8477DE4" ] ||
-					   [ $part_type_uuid == "44479540-F297-41B2-9AF7-D131D5F0458A" ] ||
-					   [ $part_type_uuid == "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" ]; then
-						dev_type="Linux"
-					elif [ $part_type_uuid == "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F" ]; then
-						dev_type="Linux/SWAP"
-					elif [ $part_type_uuid == "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" ]; then
-						dev_type="EFI/ESP"
-					else
-						dev_type=$part_type_uuid
-					fi
+				if [ $part_type_uuid == "0FC63DAF-8483-4772-8E79-3D69D8477DE4" ] ||
+				   [ $part_type_uuid == "44479540-F297-41B2-9AF7-D131D5F0458A" ] ||
+				   [ $part_type_uuid == "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" ]; then
+					dev_type="Linux"
+				elif [ $part_type_uuid == "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F" ]; then
+					dev_type="Linux/SWAP"
+				elif [ $part_type_uuid == "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" ]; then
+					dev_type="EFI/ESP"
 				else
-					part_type_id=$(fdisk -l | grep -w "$device" | sed 's/\*//' | awk '{print $6}')
-
-					if [ $part_type_id == "83" ]; then
-						dev_type="Linux"
-					elif [ $part_type_id == "82" ]; then
-						dev_type="Linux/SWAP"
-					else
-						dev_type=$part_type_id
-					fi
+					dev_type=$part_type_uuid
 				fi
+			else
+				part_type_id=$(fdisk -l | grep -w "$device" | sed 's/\*//' | awk '{print $6}')
+
+				if [ $part_type_id == "83" ]; then
+					dev_type="Linux"
+				elif [ $part_type_id == "82" ]; then
+					dev_type="Linux/SWAP"
+				else
+					dev_type=$part_type_id
+				fi
+			fi
 		fi
 
 		echo "\"$device\" \"$dev_size $dev_used $dev_fs $dev_mnt $dev_type\" \\" >> "$tmp_list"

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,7 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:] ]//g' | column -t | sort | uniq)
+	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:]., ]//g' | column -t | sort | uniq)
 	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,7 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:]., ]//g' | column -t | sort -k 1,1 | uniq)
+	device_list=$(lsblk -ni | egrep -v "$USB|loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:]., ]//g' | column -t | sort -k 1,1 | uniq)
 	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -625,7 +625,7 @@ part_menu() {
 					elif [ $part_type_uuid == "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" ]; then
 						part_type="EFI/ESP"
 					else
-						part_type="Unknown"
+						part_type=$part_type_uuid
 					fi
 				else
 					part_type_id=$(fdisk -l | grep -w "$device" | sed 's/\*//' | awk '{print $6}')
@@ -635,7 +635,7 @@ part_menu() {
 					elif [ $part_type_id == "82" ]; then
 						part_type="Linux/SWAP"
 					else
-						part_type="Unknown"
+						part_type=$part_type_id
 					fi
 				fi
 

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -603,7 +603,7 @@ part_menu() {
 		dev_size=$(lsblk | grep -m 1 -w "$device" | awk '{print $4}')
 
 		if (<<<"$dev_type" egrep "disk|raid[0-9]+" &> /dev/null) then
-			echo "\"$device\" \"$dev_size - - - $dev_type\" \\" >> $tmp_list
+			echo "\"$device\" \"$dev_size ---- ---- ---- $dev_type\" \\" >> $tmp_list
 		else
 				mnt_point=$(df | grep -w "$device" | awk '{print $6}')
 				if (<<<"$mnt_point" grep "/" &> /dev/null) then
@@ -640,15 +640,15 @@ part_menu() {
 				fi
 
 				if [ -z $part_used ]; then
-					part_used="-"
+					part_used="----"
 				fi
 
 				if [ -z $fs_type ]; then
-					fs_type="-"
+					fs_type="----"
 				fi
 
 				if [ -z $mnt_point ]; then
-					mnt_point="-"
+					mnt_point="----"
 				fi
 
 				echo "\"$device\" \"$dev_size $part_used $fs_type $mnt_point $part_type\" \\" >> "$tmp_list"

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -587,7 +587,7 @@ part_menu() {
 	unset part
 	tmp_menu=/tmp/part.sh tmp_list=/tmp/part.list
 	dev_menu="|  Device:  |  Size:  |  Used:  |  FS:  |  Mount:  |  Type:  |"
-	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:]., ]//g' | column -t | sort | uniq)
+	device_list=$(lsblk -ni | egrep -v "loop[0-9]+|sr[0-9]+|fd[0-9]+" | sed 's/[^[:alnum:]., ]//g' | column -t | sort -k 1,1 | uniq)
 	device_count=$(<<<"$device_list" wc -l)
 
 	if "$screen_h" ; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -610,7 +610,12 @@ part_menu() {
 					fs_type="$(df -T | grep -w "$device" | awk '{print $2}')"
 					part_used=$(df -T | grep -w "$device" | awk '{print $6}')
 				else
-					unset fs_type part_used
+					part_used=$(swapon -s | grep -w "$device" | awk '{print $4}')
+					if [ -n "$part_used" ]; then
+						part_used=$part_used%
+					fi
+
+					unset fs_type
 				fi
 
 				if (fdisk -l | grep "gpt" &>/dev/null) then


### PR DESCRIPTION
Here is a summary of what I have done:
 - the Partition Menu table looks complete and shows more information
 - the file system is determined even if the device/partition is not mounted
 - the devices are properly sorted by device name
 - all devices have a friendly device type obtained by either lsblk or fdisk
 - used swap space is shown after a swap partition is enabled just like the rest of the partitions
 - the file system for the swap partitions is shown as "swap"
 - the mount point is the actual mount point that is going to be on the newly installed system (/, /boot, /home, etc) instead of the current one (/mnt, /mnt/boot, /mnt/home, etc)
 - the USB stick we have booted from and all CD/DVD and floppy devices are filtered out from the table
 - performance improvements: we call lsblk twice and fdisk three times instead of calling fdisk 10 times. lsblk is faster than fdisk -l.

Happy testing.
 
![part_menu](https://cloud.githubusercontent.com/assets/6212427/23118083/bb87a8a0-f707-11e6-8489-d7f951452185.png)

![part_menu2](https://cloud.githubusercontent.com/assets/6212427/23118564/749cb0d2-f709-11e6-9f03-63f0f1a70a1d.png)

