### PR TITLE
Support installation on md devices and partitions

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -816,7 +816,11 @@ part_class() {
 			case "$part_size" in
 				[4-9]G|[1-9][0-9]*G|[4-9].*G|[4-9],*G|T)
 					if (dialog --yes-button "$yes" --no-button "$no" --defaultno --yesno "\n$root_var" 13 60) then
-						f2fs=$(cat /sys/block/$(echo $part | sed 's/[0-9]\+$//;/[0-9]/s/p$//')/queue/rotational)
+						if (<<<"$part" egrep "md[0-9]+$" &> /dev/null); then
+							f2fs=$(cat /sys/block/$part/queue/rotational)
+						else
+							f2fs=$(cat /sys/block/$(echo $part | sed 's/[0-9]\+$//;/[0-9]/s/p$//')/queue/rotational)
+						fi
 						fs_select
 
 						if [ "$?" -gt "0" ]; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -671,7 +671,7 @@ part_class() {
 		unset DRIVE ROOT
 		prepare_drives
 	elif (<<<$part grep -E "sd[a-z]+[0-9]+|[a-z]+[[:alnum:]]+p[0-9]+" &> /dev/null); then
-		part_size=$(fdisk -l | grep -w "$part" | sed 's/\*//' | awk '{print $5}')
+		part_size=$(<<<"$device_list" grep -w "$part" | awk '{print $2}')
 		part_mount=$(df | grep -w "$part" | awk '{print $6}' | sed 's/mnt\/\?//')
 		source "$lang_file"  &> /dev/null
 
@@ -974,7 +974,7 @@ part_class() {
 			fi
 		fi
 	else
-		part_size=$(fdisk -l | grep -w "$part" | awk '{print $3,$4}' | sed 's/,$//')
+		part_size=$(<<<"$device_list" grep -w "$part" | awk '{print $2}')
 		source "$lang_file"
 
 		if (df | grep -w "$part" | grep "$ARCH" &> /dev/null); then	

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -672,7 +672,7 @@ part_class() {
 		prepare_drives
 	elif (<<<$part grep -E "sd[a-z]+[0-9]+|[a-z]+[[:alnum:]]+p[0-9]+" &> /dev/null); then
 		part_size=$(fdisk -l | grep -w "$part" | sed 's/\*//' | awk '{print $5}')
-		part_mount=$(df | grep -w "$part" | awk '{print $6}' | sed 's/\/mnt/\//;s/\/\//\//')
+		part_mount=$(df | grep -w "$part" | awk '{print $6}' | sed 's/mnt\/\?//')
 		source "$lang_file"  &> /dev/null
 
 		if [ -z "$ROOT" ]; then
@@ -879,7 +879,7 @@ part_class() {
 				BOOT="$ROOT"
 			fi
 
-			final_part=$((df -h | grep "$ARCH" | awk '{print $1,$2,$6 "\\n"}' | sed 's/\/mnt/\//;s/\/\//\//' ; swapon | awk 'NR==2 {print $1,$3,"SWAP"}') | column -t)
+			final_part=$((df -h | grep "$ARCH" | awk '{print $1,$2,$6 "\\n"}' | sed 's/mnt\/\?//' ; swapon | awk 'NR==2 {print $1,$3,"SWAP"}') | column -t)
 			final_count=$(<<<"$final_part" wc -l)
 
 			if [ "$final_count" -lt "7" ]; then

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -678,7 +678,7 @@ part_class() {
 	fi
 
 	if [ "$part_fs" == "linux_raid_member" ]; then # do nothing
-		:
+		part_menu
 	elif ([ "$part_type" == "disk" ]) || ( (<<<"$part_type" egrep "raid[0-9]+" &> /dev/null) && [ -z "$part_fs" ] ); then # Partition
 
         source "$lang_file"

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -670,9 +670,13 @@ part_class() {
 	if [ -z "$part" ]; then
 		unset DRIVE ROOT
 		prepare_drives
-	elif (<<<$part grep -E "sd[a-z]+[0-9]+|[a-z]+[[:alnum:]]+p[0-9]+" &> /dev/null); then
+	else
+		part_fs=$(<<<"$device_list" grep -w "$part" | awk '{print $4}')
 		part_size=$(<<<"$device_list" grep -w "$part" | awk '{print $2}')
 		part_mount=$(df | grep -w "$part" | awk '{print $6}' | sed 's/mnt\/\?//')
+	fi
+
+	if (<<<$part grep -E "sd[a-z]+[0-9]+|[a-z]+[[:alnum:]]+p[0-9]+" &> /dev/null); then
 		source "$lang_file"  &> /dev/null
 
 		if [ -z "$ROOT" ]; then
@@ -974,7 +978,6 @@ part_class() {
 			fi
 		fi
 	else
-		part_size=$(<<<"$device_list" grep -w "$part" | awk '{print $2}')
 		source "$lang_file"
 
 		if (df | grep -w "$part" | grep "$ARCH" &> /dev/null); then	


### PR DESCRIPTION
I deal with software RAID quite often and I wanted to be able to install on md devices that do not contain any partitions and are pre-formatted. The logic is quite tricky since md0 could be treated as something you could partition into smaller partition (like sda) or the whole device could be formatted with any file system without having any partitions (unlike sdX). This is why this took more changes than I would like. 

Here is a short summary of the implemented workflow:
- The partitioning procedure is triggered on disks (sda, nvme0n1, etc) and md devices (mdX) iff they have no file system.
- The installation procedure is triggered on partitions (sdaX, nvme0n1pX, etc), md partitions (md0pX) and md devices (mdX) iff they are pre-formatted with a file system.
- Partitions with FSTYPE=linux_raid_member are not altered and selecting them just reloads part_menu. A custom error message could be added but it is not a big deal. The less dialogs the better.

I hope I have not broken any existing functionality. Let me know how the new changes are working for you.

![part_menu3](https://cloud.githubusercontent.com/assets/6212427/23151981/8c7dc466-f7b3-11e6-8061-fcf874af60f9.png)

