### PR TITLE
No need for this work-around any longer

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -67,7 +67,6 @@ init() {
 	esac
 
 	source "$lang_file"
-	set_lang="$LANG"
 	export reload=true
 	update_mirrors
 
@@ -282,7 +281,6 @@ prepare_drives() {
 	if [ "$?" -gt "0" ] || [ "$PART" == "$menu_msg" ]; then
 		main_menu
 	elif [ "$PART" != "$method2" ]; then
-		LANG=en_US.UTF-8
 		dev_menu="           Device: | Size: | Type:  |"
 		if "$screen_h" ; then
 			cat <<-EOF > "$tmp_menu"
@@ -383,8 +381,6 @@ prepare_drives() {
 		fi
 	fi
 	
-	LANG="$set_lang"
-
 	case "$PART" in
 		"$method0") auto_part	
 		;;


### PR DESCRIPTION
This work-around was added in d96bc21fb8916d6704c8d0df925d56a1ca063a0d (2months/285 commits ago) since some of the regular expressions contained English words at that time. Now all regular expressions are language agnostic which makes the work-around unnecessary.