### PR TITLE
Colorize the prompt for bash login shells as well

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -1905,8 +1905,10 @@ configure_system() {
 		arch-chroot "$ARCH" systemctl enable dhcpcd.service &> /dev/null &
 		pid=$! pri=0.1 msg="\n$dhcp_load \n\n \Z1> \Z2systemctl enable dhcpcd\Zn" load
 	fi
-	
-	if [ "$sh" == "/usr/bin/zsh" ]; then
+
+	if [ "$sh" == "/bin/bash" ]; then
+		cp "$ARCH"/etc/skel/.bash_profile "$ARCH"/root/
+	elif [ "$sh" == "/usr/bin/zsh" ]; then
 		cp "$aa_dir"/extra/.zshrc "$ARCH"/root/
 		cp "$aa_dir"/extra/.zshrc "$ARCH"/etc/skel/
 	elif [ "$shell" == "fish" ]; then


### PR DESCRIPTION
Login shells source ~/.bash_profile and non-login shells source ~/.bashrc.

The first thing I do when I login as root for the very first time on a freshly installed system is:
`cp /home/<myuser>/.bash_profile .`

This will be no more.