### PR TITLE
Properly handle leading and trailing whitespaces in $done_msg

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -668,7 +668,6 @@ part_menu() {
 	echo "if [ \"\$?\" -eq \"3\" ]; then clear ; echo \"$done_msg\" ; fi" >> "$tmp_menu"
 	part=$(bash "$tmp_menu" | sed 's/ //g')
 	rm $tmp_menu $tmp_list
-	if (<<<"$part" grep "$done_msg" &> /dev/null) then part="$done_msg" ; fi
 	part_class
 
 }

--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -666,7 +666,7 @@ part_menu() {
 	<"$tmp_list" column -t >> "$tmp_menu"
 	echo "\"$done_msg\" \"$write\" 3>&1 1>&2 2>&3" >> "$tmp_menu"
 	echo "if [ \"\$?\" -eq \"3\" ]; then clear ; echo \"$done_msg\" ; fi" >> "$tmp_menu"
-	part=$(bash "$tmp_menu" | sed 's/ //g')
+	part=$(bash "$tmp_menu" | sed 's/^\s\+//g;s/\s\+$//g')
 	rm $tmp_menu $tmp_list
 	part_class
 


### PR DESCRIPTION
`if (<<<"$manual_part" grep "$done_msg") then manual_part="$done_msg" ; fi`

This line was added in 4c19cfa32cc165a6789c1998a082bac7ca240ba5 and I am not entirely sure why. I suspect this serves as an unconventional way to get rid of leading and trailing whitespaces.

I removed the line and changed the regex so that only the leading and trailing whitespaces are trimmed. The old code removes all spaces in the string which will be wrong if in some languages the translation of the word "Done" contains two or more words. This will concatenate the words and part_class will not work as expected:
`elif [ "$part" == "$done_msg" ]; then`