### PR TITLE
Add possibility to select packages for desktop before iso generation

### DIFF
--- a/arch-anywhere-creator.sh
+++ b/arch-anywhere-creator.sh
@@ -76,7 +76,7 @@ if [ "$iso_ver" != "$iso" ]; then
 	if [ -z "$iso" ]; then
 		echo -en "\nNo archiso found under $aa\nWould you like to download now? [y/N]: "
 		read input
-    
+
 		case "$input" in
 			y|Y|yes|Yes|yY|Yy|yy|YY) update=true
 			;;
@@ -87,7 +87,7 @@ if [ "$iso_ver" != "$iso" ]; then
 	else
 		echo -en "An updated version of the archiso is available for download\n'$iso_ver'\nDownload now? [y/N]: "
 		read input
-		
+
 		case "$input" in
 			y|Y|yes|Yes|yY|Yy|yy|YY) update=true
 			;;
@@ -96,7 +96,7 @@ if [ "$iso_ver" != "$iso" ]; then
 			;;
 		esac
 	fi
-	
+
 	if "$update" ; then
 		cd "$aa"
 		wget "$archiso_link"
@@ -109,11 +109,11 @@ if [ "$iso_ver" != "$iso" ]; then
 fi
 
 init() {
-	
+
 	if [ -d "$customiso" ]; then
 		sudo rm -rf "$customiso"
 	fi
-	
+
 	# Extract archiso to mntdir and continue with build
 	7z x "$iso" -o"$customiso"
 	builds
@@ -152,7 +152,7 @@ builds() {
 }
 
 prepare_sys() {
-	
+
 ### Set system architecture
 	sys=x86_64
 
@@ -179,6 +179,7 @@ prepare_sys() {
 ### Copy over main arch anywhere config, installer script, and arch-wiki,  make executeable
 	sudo cp "$aa"/etc/arch-anywhere.conf "$customiso"/arch/"$sys"/squashfs-root/etc/
 	sudo cp "$aa"/arch-installer.sh "$customiso"/arch/"$sys"/squashfs-root/usr/bin/arch-anywhere
+	sudo cp "$aa"/packages "$customiso"/arch/"$sys"/squashfs-root/etc/
 	sudo cp "$aa"/extra/{sysinfo,iptest} "$customiso"/arch/"$sys"/squashfs-root/usr/bin/
 	sudo chmod +x "$customiso"/arch/"$sys"/squashfs-root/usr/bin/{arch-anywhere,sysinfo,iptest}
 
@@ -210,21 +211,21 @@ prepare_sys() {
 	sudo mksquashfs squashfs-root airootfs.sfs -b 1024k -comp xz
 	sudo rm -r squashfs-root
 	md5sum airootfs.sfs > airootfs.md5
-	
+
 ### Begin configure boot function
 	configure_boot
 
 }
 
 configure_boot() {
-	
+
 	archiso_label=$(<"$customiso"/loader/entries/archiso-x86_64.conf awk 'NR==5{print $NF}' | sed 's/.*=//')
 	archiso_hex=$(<<<"$archiso_label" xxd -p)
 	iso_hex=$(<<<"$iso_label" xxd -p)
 	cp "$aa"/boot/splash.png "$customiso"/arch/boot/syslinux
 	cp "$aa"/boot/iso/archiso_head.cfg "$customiso"/arch/boot/syslinux
 	sed -i "s/$archiso_label/$iso_label/" "$customiso"/loader/entries/archiso-x86_64.conf
-	sed -i "s/$archiso_label/$iso_label/" "$customiso"/arch/boot/syslinux/archiso_sys.cfg 
+	sed -i "s/$archiso_label/$iso_label/" "$customiso"/arch/boot/syslinux/archiso_sys.cfg
 	sed -i "s/$archiso_label/$iso_label/" "$customiso"/arch/boot/syslinux/archiso_pxe.cfg
 	cd "$customiso"/EFI/archiso/
 	echo -e "Replacing label hex in efiboot.img...\n$archiso_label $archiso_hex > $iso_label $iso_hex"

--- a/lib/configure_desktop.sh
+++ b/lib/configure_desktop.sh
@@ -29,6 +29,7 @@ graphics() {
 		de=$(dialog --separate-output --ok-button "$done_msg" --cancel-button "$cancel" --checklist "$environment_msg" 24 60 15 \
 			"AA-Xfce"			"$de15" OFF \
 			"AA-Openbox"		"$de18" OFF \
+			"Own-Packages"      "$de19" OFF \
 			"budgie"			"$de17" OFF \
 			"cinnamon"      	"$de5" OFF \
 			"deepin"			"$de14" OFF \
@@ -74,6 +75,8 @@ graphics() {
 							sed -i -e '$a\\n[arch-anywhere]\nServer = http://arch-anywhere.org/repo/$arch\nSigLevel = Never' /etc/pacman.conf
 							start_term="exec openbox-session"
 			;;
+			"Own-Packages") source /etc/packages
+			;;
 			"xfce4") 	DE+="xfce4 "
 						if (dialog --yes-button "$yes" --no-button "$no" --yesno "\n$extra_msg0" 10 60) then
 							DE+="xfce4-goodies "
@@ -107,18 +110,18 @@ graphics() {
 			;;
 			"KDE plasma")	if (dialog --defaultno --yes-button "$yes" --no-button "$no" --yesno "\n$extra_msg3" 10 60) then
 								DE+="plasma-desktop sddm konsole dolphin plasma-nm plasma-pa libxshmfence kscreen "
-    
+
 								if "$LAPTOP" ; then
 									DE+="powerdevil "
 								fi
 							else
 								DE+="plasma kde-applications "
 							fi
-    
+
 							if [ -n "$kdel" ]; then
 								DE+="kde-l10n-$kdel "
 							fi
-    
+
 							start_term="exec startkde"
 			;;
 			"deepin")	DE+="deepin "
@@ -294,7 +297,7 @@ graphics() {
 	done
 
 	DE+="$GPU xdg-user-dirs xorg-server xorg-server-utils xorg-xinit xterm ttf-dejavu gvfs pulseaudio pavucontrol pulseaudio-alsa alsa-utils unzip "
-	
+
 	if [ "$net_util" == "networkmanager" ] ; then
 		if (<<<"$DE" grep "plasma" &> /dev/null); then
 			DE+="plasma-nm "

--- a/packages
+++ b/packages
@@ -1,0 +1,7 @@
+# This is an example to choose which package you want install
+# This packages are used when you choose the "Own-Packages" option in desktop menu
+#
+# DE+="gnome-shell guake gnome-control-center gnome-tweak-tool mpv lollypop atom nemo chromium transmission-gtk eog gitg "
+# start_term="exec gnome-session"
+DE+="gnome-shell guake gnome-control-center gnome-tweak-tool "
+start_term="exec gnome-session"


### PR DESCRIPTION
Personnality I use gnome, but I never install the gnome group because there are thing that I don't use. 
I wanted to find a solution to personnalise the installation.

When you select your desktop, I add an entry Own-Packages and a package file in arch-anywhere root that is only sourced.

The package file is copied in /etc/packages. I don't know if it's the better place to put it.