### PR TITLE
Properly show the device type for all devices

### DIFF
--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -415,7 +415,7 @@ part_menu() {
 			fi
 		fi
 
-		test -z "$dev_fs" && dev_fs=$empty_value
+		test -z "$dev_fs" || test "$dev_fs" == "linux_raid_member" && dev_fs=$empty_value
 		test -z "$dev_used" && dev_used=$empty_value
 		test -z "$dev_mnt" && dev_mnt=$empty_value
 

--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -422,7 +422,7 @@ part_menu() {
 		if [ -z "$parent_device" ]; then
 			dev_type=$(<<<"$device_list" grep -w "$device" | awk '{print $3}')
 		else
-			dev_type=$(fdisk -lo Device,Type /dev/$parent_device | grep -w "$device" | cut -d ' ' -f 2- | sed -e 's/^[[:space:]]*//;s/[[:space:]]*$//')
+			dev_type=$(fdisk -lo Device,Type /dev/$parent_device | grep -w "$device" | cut -d ' ' -f 2- | sed -e 's/^[[:space:]]*//;s/[[:space:]]*$//;s/ /_/g')
 		fi
 
 		echo "\"$device\" \"$dev_size $dev_used $dev_fs $dev_mnt $dev_type\" \\" >> "$tmp_list"


### PR DESCRIPTION
I think it looks better now:
The device type is obtained from lsblk if it is a parent device (sda, md0...). If the device is a partition (sda1, md0p1...) the device type is obtained from fdisk.
![dev_type1](https://cloud.githubusercontent.com/assets/6212427/25072934/b78ccab0-228f-11e7-9609-91876f1405f1.png)

![dev_type2](https://cloud.githubusercontent.com/assets/6212427/25072935/bb848356-228f-11e7-9b22-755ef986cf6f.png)

**Note 1:** sdd and sde are "gpt". The rest are "dos".

**Note 2:** The underscores in the values from the last column are needed because "column -t" breaks the table if the strings contain whitespaces.