### PR TITLE
Enable auto-boot after 5 seconds

### DIFF
--- a/boot/loader/syslinux/syslinux.cfg
+++ b/boot/loader/syslinux/syslinux.cfg
@@ -1,5 +1,6 @@
 SERIAL 0 38400
 UI vesamenu.c32
+TIMEOUT 50
 MENU TITLE Arch Linux
 MENU BACKGROUND splash.png
 

--- a/boot/loader/syslinux/syslinux_efi.cfg
+++ b/boot/loader/syslinux/syslinux_efi.cfg
@@ -1,5 +1,6 @@
 SERIAL 0 38400
 UI vesamenu.c32
+TIMEOUT 50
 MENU TITLE Arch Linux
 MENU BACKGROUND splash.png
 


### PR DESCRIPTION
I think it is a good idea having this by default. I already suffered from rebooting a remote machine without having the TIMEOUT option.