### PR TITLE
Replacing xorg-server-utils by xorg-apps

### DIFF
--- a/lib/configure_desktop.sh
+++ b/lib/configure_desktop.sh
@@ -293,7 +293,7 @@ graphics() {
 		fi
 	done
 
-	DE+="$GPU xdg-user-dirs xorg-server xorg-server-utils xorg-xinit xterm ttf-dejavu gvfs pulseaudio pavucontrol pulseaudio-alsa alsa-utils unzip "
+	DE+="$GPU xdg-user-dirs xorg-server xorg-apps xorg-xinit xterm ttf-dejavu gvfs pulseaudio pavucontrol pulseaudio-alsa alsa-utils unzip "
 	
 	if [ "$net_util" == "networkmanager" ] ; then
 		if (<<<"$DE" grep "plasma" &> /dev/null); then


### PR DESCRIPTION
Xorg-apps is now replacing xorg-server-utils in Archlinux extra repository as noticed in bug #319