### PR TITLE
Update arch-installer-french.conf

### DIFF
--- a/lang/arch-installer-french.conf
+++ b/lang/arch-installer-french.conf
@@ -123,7 +123,6 @@ office4="Suite bureautique vers. récente"
 office5="Suite bureautique vers. stable"
 
 ### Terminal
-term0="Émulateur de Terminal"
 term1="Émulateur de Terminal à la Quake"
 term2="Émulateur de Terminal"
 term3="Émulateur de Terminal pour Pantheon"


### PR DESCRIPTION
Removing term0 as fbterm was removed in this commit : https://github.com/deadhead420/arch-linux-anywhere/commit/80e4366da748691f94bc4088ced8981d2c5940ac