### PR TITLE
set up fstab correctly on encrypted UEFI installations

### DIFF
--- a/lib/configure_system.sh
+++ b/lib/configure_system.sh
@@ -77,7 +77,7 @@ configure_system() {
 	fi
 
 	if "$crypted" && "$UEFI" ; then
-		echo "/dev/$BOOT              $esp           vfat         rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro        0       2" > "$ARCH"/etc/fstab
+		echo "/dev/$BOOT              $esp_mnt        vfat         rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro        0       2" > "$ARCH"/etc/fstab
 	elif "$crypted" ; then
 		echo "/dev/$BOOT              /boot           $FS         defaults        0       2" > "$ARCH"/etc/fstab
 	fi


### PR DESCRIPTION
Fix bug in fstab generation. Use `$esp_mnt` (`$esp` is not defined).
This solves #360.