### PR TITLE
Add Btrfs support for the /boot partition

### DIFF
--- a/lib/configure_device.sh
+++ b/lib/configure_device.sh
@@ -716,7 +716,7 @@ part_class() {
 				if (dialog --yes-button "$yes" --no-button "$no" --defaultno --yesno "\n$part_frmt_msg" 11 50) then
 					f2fs=$(lsblk -dnro ROTA /dev/$part)
 
-					if [ "$mnt" == "/boot" ] || [ "$mnt" == "/boot/EFI" ] || [ "$mnt" == "/boot/efi" ]; then
+					if [ "$mnt" == "/boot/EFI" ] || [ "$mnt" == "/boot/efi" ]; then
 						f2fs=1
 						btrfs=false
 					fi


### PR DESCRIPTION
GRUB supports Btrfs which means we can enable Btrfs for the /boot partition.