### PR TITLE
Rewrite update functionality

### DIFF
--- a/etc/arch-anywhere.conf
+++ b/etc/arch-anywhere.conf
@@ -105,30 +105,24 @@ case "$opt" in
 		fi
 	;;
 	-u|--update) 
-		echo -e "\n${Yellow}*> Arch-Anywhere: Updating installer..."
-		wget -4 --no-check-certificate -O /usr/bin/arch-anywhere https://raw.githubusercontent.com/deadhead420/arch-linux-anywhere/master/arch-installer.sh &>/dev/null
+                tmp_dir=$(mktemp -d)
+		echo -ne "\n${Yellow}*> Arch-Anywhere: Downloading..."
+		wget -q -4 --no-check-certificate -O $tmp_dir/master.tar.gz https://github.com/deadhead420/arch-linux-anywhere/archive/master.tar.gz
 		if [ "$?" -gt "0" ]; then
-			echo "${Red}*> Error: ${Yellow}Active network connection not detected - Please connect to the internet and try again. Exiting..."
+			echo -e "${Red}*> Error: ${Yellow}Active network connection not detected - Please connect to the internet and try again. Exiting..."
 			exit 1
 		fi
-		echo -e "  ${Green}*> Updated: ${Yellow}/usr/bin/arch-anywhere"
-		
-		echo -e "\n${Yellow}*> Arch-Anywhere: Updating functions..."
-		for file in $(ls /usr/lib/arch-anywhere) ; do
-			wget -4 --no-check-certificate -O /usr/lib/arch-anywhere/$file https://raw.githubusercontent.com/deadhead420/arch-linux-anywhere/master/lib/$file &>/dev/null
-			echo -e "  ${Green}*> Updated: ${Yellow}$file"
-		done
+		echo -e "${Green}done"
 
-		echo -e "\n${Yellow}*> Arch-Anywhere: Updating configuration..."
-		wget -4 --no-check-certificate -O /etc/arch-anywhere.conf https://raw.githubusercontent.com/deadhead420/arch-linux-anywhere/master/etc/arch-anywhere.conf &>/dev/null
-		echo -e "  ${Green}*> Updated: ${Yellow}/etc/arch-anywhere.conf"
-				 
-		echo -e "\n${Yellow}*> Arch-Anywhere: Updating language..."
-		for file in $(ls /usr/share/arch-anywhere/lang) ; do
-			wget -4 --no-check-certificate -O /usr/share/arch-anywhere/lang/$file https://raw.githubusercontent.com/deadhead420/arch-linux-anywhere/master/lang/$file &>/dev/null
-			echo -e "  ${Green}*> Updated: ${Yellow}$file"
-		done
-				 
+		echo -ne "\n${Yellow}*> Arch-Anywhere: Updating..."
+		tar zxf $tmp_dir/master.tar.gz -C $tmp_dir
+		cp $tmp_dir/arch-linux-anywhere-master/arch-installer.sh /usr/bin/arch-anywhere
+		cp $tmp_dir/arch-linux-anywhere-master/etc/arch-anywhere.conf /etc/arch-anywhere.conf
+		cp $tmp_dir/arch-linux-anywhere-master/lib/* /usr/lib/arch-anywhere/
+		cp $tmp_dir/arch-linux-anywhere-master/lang/* /usr/share/arch-anywhere/lang/
+		cp -r $tmp_dir/arch-linux-anywhere-master/extra/* /usr/share/arch-anywhere/extra/
+		echo -e "${Green}done"
+
 		echo -e "\n${Green}*> ${Yellow}Arch Anywhere updated successfully, you may now run arch-anywhere ${ColorOff}"
 		exit
 	;;


### PR DESCRIPTION
With the old implementation any new files under `lib/`, `extra/` and `lang/` that are added to the repo will not get downloaded. The new implementation solves that problem by downloading the whole project as a tar.gz file and then:
- copies `arch-installer.sh` to `/usr/bin/arch-anywhere`
- copies `etc/arch-anywhere.conf` to `/etc/arch-anywhere.conf`
- copies all files under `lib/` to `/usr/lib/arch-anywhere/`
- copies all files under `lang/` to `/usr/share/arch-anywhere/lang/`
- copies all files and dirs under `extra/` to `/usr/share/arch-anywhere/extra/`