### PR TITLE
Adding back translations accidentaly removed

### DIFF
--- a/lang/arch-installer-french.conf
+++ b/lang/arch-installer-french.conf
@@ -846,6 +846,13 @@ sys24="Calculatrice en mode graphique"
 sys25="Calculatrice en CLI"
 sys26="Gestionnaire de paquets pour GNOME"
 sys27="Outils logiciels GNOME"
+sys28="Pilotes et utilitaires pour NTFS"
+sys29="Langage de script Web"
+sys30="Serveur de base de données SQL"
+sys31="Gestion de base de données relationnelle avancé"
+sys32="Interface Web pour administrer MySQL"
+sys33="Langage de script de haut niveau"
+sys34="Économiseur d'écran pour Xorg"
 
 # Titre
 title=" -| Arch Linux Anywhere |- "
@@ -886,7 +893,7 @@ srv8="Serveur proxy complet pour le Web"
 srv9="Serveur de fichiers SMB et de domaine AD"
 srv10="Serveur de noms de domaine ISC"
 srv11="Serveur d'impression CUPS"
-sys1="Apache"
+sys1="Serveur HTTP Apache"
 sys10="OpenSSH"
 
 ### Shells


### PR DESCRIPTION
sys28 to sys34 lines. What happened?