### PR TITLE
fix: typo Anarchy-Dekstop in lang files

### DIFF
--- a/lang/bulgarian.conf
+++ b/lang/bulgarian.conf
@@ -106,7 +106,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/dutch.conf
+++ b/lang/dutch.conf
@@ -128,7 +128,7 @@ more_wm="Meer Window Managers"
 
 more_wm_msg="Standaard Window Managers =>"
 
-install_opt_msg="Selecteer uw installatie optie: \n\n $a Snelle install selecteer 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Geavanceerde install opties selecteer 'Anarchy-Advanced'"
+install_opt_msg="Selecteer uw installatie optie: \n\n $a Snelle install selecteer 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Geavanceerde install opties selecteer 'Anarchy-Advanced'"
 
 install_opt0="Geavanceerde installatie opties"
 

--- a/lang/german.conf
+++ b/lang/german.conf
@@ -650,7 +650,7 @@ complete_op_msg=" -| Installation abgeschlossen |- "
 
 menu_op_msg=" -| Hauptmenü |- "
 
-install_opt_msg="Wählen Sie die gewünschte Installtionsoption: \n\n $a Für Schnellinstallation wählen Sie: 'Anarchy-Dekstop' oder 'Anarchy-Server' \n $a Für erweiterte Installationsoptionen wählen Sie: 'Anarchy-Advanced'"
+install_opt_msg="Wählen Sie die gewünschte Installtionsoption: \n\n $a Für Schnellinstallation wählen Sie: 'Anarchy-Desktop' oder 'Anarchy-Server' \n $a Für erweiterte Installationsoptionen wählen Sie: 'Anarchy-Advanced'"
 
 install_opt0="Erweiterte Installationsoptionen"
 

--- a/lang/greek.conf
+++ b/lang/greek.conf
@@ -170,7 +170,7 @@ more_wm_msg="Default Window Managers =>"
 
 user_op_msg1=" -| Edit User |- "
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/hungarian.conf
+++ b/lang/hungarian.conf
@@ -112,7 +112,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/indonesia.conf
+++ b/lang/indonesia.conf
@@ -75,7 +75,7 @@ user_msg2="Set full username: \n\n $a Write your full name"
 
 user_err_msg1="$error username already in use. \n\n $a Please try again"
 
-user_err_msg2="$error you must enter a username \n\n $a Please try again" 
+user_err_msg2="$error you must enter a username \n\n $a Please try again"
 
 fulluser_err_msg="$error There are forbidden characters (,)\n\n $a Please try again"
 
@@ -177,7 +177,7 @@ more_wm_msg="Default Window Managers =>"
 
 user_op_msg1=" -| Edit User |- "
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/italian.conf
+++ b/lang/italian.conf
@@ -118,7 +118,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/latvian.conf
+++ b/lang/latvian.conf
@@ -116,7 +116,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/lithuanian.conf
+++ b/lang/lithuanian.conf
@@ -110,7 +110,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/polish.conf
+++ b/lang/polish.conf
@@ -651,7 +651,7 @@ complete_op_msg=" -| Instalacja Zakończona |- "
 
 menu_op_msg=" -| Menu Główne |- "
 
-install_opt_msg="Wybierz żądaną opcję instalacji: \n\n $a Szybka instalacja wybierz 'Anarchy-Dekstop' lub 'Anarchy-Server' \n $a Zaawansowane opcje instalacji wybierz 'Anarchy-Advanced'"
+install_opt_msg="Wybierz żądaną opcję instalacji: \n\n $a Szybka instalacja wybierz 'Anarchy-Desktop' lub 'Anarchy-Server' \n $a Zaawansowane opcje instalacji wybierz 'Anarchy-Advanced'"
 
 install_opt0="Zaawansowane opcje instalacji"
 

--- a/lang/portuguese-br.conf
+++ b/lang/portuguese-br.conf
@@ -20,7 +20,7 @@ fonts="Fontes"
 
 fonts_msg="Fontes Linux =>"
 
-install_opt_msg="Selecione a opção de instalação desejada: \n\n $a Instalação rápida selecione 'Anarchy-Dekstop' ou 'Anarchy-Server' \n $a Opções avançadas de instalação selecione 'Anarchy-Advanced'"
+install_opt_msg="Selecione a opção de instalação desejada: \n\n $a Instalação rápida selecione 'Anarchy-Desktop' ou 'Anarchy-Server' \n $a Opções avançadas de instalação selecione 'Anarchy-Advanced'"
 
 install_opt0="Opções avançadas de instalação"
 

--- a/lang/portuguese.conf
+++ b/lang/portuguese.conf
@@ -442,7 +442,7 @@ gr9="NVIDIA 390xx $drivers"
 
 gr10="AMDGPU Video ${drivers}"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/romanian.conf
+++ b/lang/romanian.conf
@@ -658,7 +658,7 @@ complete_op_msg=" -| Instalare completă |- "
 
 menu_op_msg=" -| Meniu Principal |- "
 
-install_opt_msg="Selectați opțiunea de instalare dorită: \n\n $a Pentru instalare rapidă selectați 'Anarchy-Dekstop' sau 'Anarchy-Server' \n $a Pentru opțiuni de instalare avansată selectați 'Anarchy-Advanced'"
+install_opt_msg="Selectați opțiunea de instalare dorită: \n\n $a Pentru instalare rapidă selectați 'Anarchy-Desktop' sau 'Anarchy-Server' \n $a Pentru opțiuni de instalare avansată selectați 'Anarchy-Advanced'"
 
 install_opt0="Opțiuni avansate de instalare manuală"
 

--- a/lang/russian.conf
+++ b/lang/russian.conf
@@ -114,7 +114,7 @@ more_wm="More Window Managers"
 
 more_wm_msg="Default Window Managers =>"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 

--- a/lang/spanish.conf
+++ b/lang/spanish.conf
@@ -654,7 +654,7 @@ complete_op_msg=" -| Instalación completada |- "
 
 menu_op_msg=" -| Menú principal |- "
 
-install_opt_msg="Selecciona tu opción de instalación deseada: \n\n $a Para una instalación rápida selecciona 'Anarchy-Dekstop' (Escritorio) o 'Anarchy-Server' (Servidor) \n $a Para opciones de instalación avanzadas selecciona 'Anarchy-Advanced' (Avanzado)"
+install_opt_msg="Selecciona tu opción de instalación deseada: \n\n $a Para una instalación rápida selecciona 'Anarchy-Desktop' (Escritorio) o 'Anarchy-Server' (Servidor) \n $a Para opciones de instalación avanzadas selecciona 'Anarchy-Advanced' (Avanzado)"
 
 install_opt0="Opciones de instalación avanzadas"
 

--- a/lang/swedish.conf
+++ b/lang/swedish.conf
@@ -265,7 +265,7 @@ gr9="NVIDIA 390xx $drivers"
 
 gr10="AMDGPU Video ${drivers}"
 
-install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Dekstop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
+install_opt_msg="Select your desired install option: \n\n $a Quick install select 'Anarchy-Desktop' or 'Anarchy-Server' \n $a Advanced install options select 'Anarchy-Advanced'"
 
 install_opt0="Advanced install options"
 


### PR DESCRIPTION
## Description

In language files was typo in `install_opt_msg` key. Changed `Anarchy-Dekstop` to `Anarchy-Desktop`

## Pull request checklist

* [ ] I have tested my code
* [x ] I have read the [contributing guide](https://github.com/AnarchyLinux/installer/blob/HEAD/CONTRIBUTING.md)
* [ ] I have followed best practices and commented my code well